### PR TITLE
python path in figure constructor

### DIFF
--- a/src/matplotnim.nim
+++ b/src/matplotnim.nim
@@ -60,10 +60,10 @@ proc save*(figure: Figure, dest: string) =
   echo name
   writeFile(name, script_str)
   echo name
-  discard execShellCmd fmt"/usr/local/bin/python3 {name}"
+  discard execShellCmd figure.python & " " & name
   
-proc newFigure*(): Figure =
-  Figure(python: "/usr/local/bin/python3", 
+proc newFigure*(python = "/usr/local/bin/python3"): Figure =
+  Figure(python: python, 
          script: newSeq[string](), 
          latex: false,
          font: ("", ""),


### PR DESCRIPTION
Hi ruivieira,

thanks for creating and sharing this nice package!
I had a problem running it, because for archlinux python is in a different path, and made a quick fix. 
If you want to include it, I prepared a pull request as you wrote in the readme.

To use the fix one simply uses the python path parameter in the figure constructor, for archlinux the following works:
`  
let figure = newFigure(python="python")
`


cheers,
Simon